### PR TITLE
Create ComplexObjectFilterUtility

### DIFF
--- a/src/Microsoft.Health.Fhir.Liquid.Converter.UnitTests/Microsoft.Health.Fhir.Liquid.Converter.UnitTests.csproj
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.UnitTests/Microsoft.Health.Fhir.Liquid.Converter.UnitTests.csproj
@@ -35,4 +35,10 @@
     </None>
   </ItemGroup>
 
+  <ItemGroup>
+    <None Update="TestData\ComplexObject.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
 </Project>

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.UnitTests/Models/ComplexObjectFilterUtilityTestCase.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.UnitTests/Models/ComplexObjectFilterUtilityTestCase.cs
@@ -1,0 +1,23 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+namespace Microsoft.Health.Fhir.Liquid.Converter.UnitTests.Models
+{
+    public struct ComplexObjectFilterUtilityTestCase
+    {
+        public object[] Input;
+        public string Path;
+        public string Value;
+        public object[] Expected;
+
+        public ComplexObjectFilterUtilityTestCase(object[] input, string path, string value, object[] expected)
+        {
+            Input = input;
+            Path = path;
+            Value = value;
+            Expected = expected;
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.UnitTests/TestData/ComplexObject.json
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.UnitTests/TestData/ComplexObject.json
@@ -1,0 +1,1031 @@
+[
+  {
+    "_id": "62799a49164413a4c0d89623",
+    "index": "0",
+    "isActive": true,
+    "age": "27",
+    "name": "Shaw Walker",
+    "gender": "male",
+    "phone": "+1 (956) 587-2191",
+    "upgrades": {
+      "vision": {
+        "system": "http://infrared.org",
+        "augmentCode": "apple"
+      },
+      "bonemarrow": {
+        "system": "http://illuminated.party",
+        "augmentCode": "chameleon"
+      }
+    },
+    "friends": [
+      {
+        "id": "0",
+        "name": "Blanchard Barr",
+        "parents": [
+          {
+            "name": "Blanca Juarez",
+            "age": "50",
+            "tags": [
+              "laborum",
+              "eiusmod",
+              "aliqua",
+              "occaecat",
+              "enim",
+              "aliquip",
+              "enim"
+            ]
+          },
+          {
+            "name": "Hunter Lindsay",
+            "age": 56,
+            "tags": [
+              "officia",
+              "incididunt",
+              "cillum",
+              "sunt",
+              "adipisicing",
+              "eiusmod",
+              "do"
+            ]
+          }
+        ],
+        "favoriteFruit": "O-",
+        "tags": [
+          "cillum",
+          "aute",
+          "cupidatat",
+          "exercitation",
+          "cillum",
+          "qui",
+          "incididunt"
+        ]
+      },
+      {
+        "id": "1",
+        "name": "Kara Tillman",
+        "parents": [
+          {
+            "name": "Penny Benjamin",
+            "age": "55",
+            "tags": [
+              "sunt",
+              "ex",
+              "ea",
+              "excepteur",
+              "nisi",
+              "enim",
+              "ipsum"
+            ]
+          },
+          {
+            "name": "Corine Haley",
+            "age": "43",
+            "tags": [
+              "excepteur",
+              "dolor",
+              "pariatur",
+              "Lorem",
+              "labore",
+              "labore",
+              "ex"
+            ]
+          }
+        ],
+        "favoriteFruit": "O-",
+        "tags": [
+          "culpa",
+          "velit",
+          "sit",
+          "ut",
+          "eu",
+          "consectetur",
+          "magna"
+        ]
+      },
+      {
+        "id": "2",
+        "name": "Louise Madden",
+        "parents": [
+          {
+            "name": "Nadia Waller",
+            "age": "41",
+            "tags": [
+              "anim",
+              "culpa",
+              "consectetur",
+              "nisi",
+              "commodo",
+              "elit",
+              "dolor"
+            ]
+          },
+          {
+            "name": "Kitty Harding",
+            "age": "52",
+            "tags": [
+              "laboris",
+              "enim",
+              "consequat",
+              "aliquip",
+              "culpa",
+              "ullamco",
+              "ut"
+            ]
+          }
+        ],
+        "favoriteFruit": "B",
+        "tags": [
+          "nisi",
+          "ad",
+          "mollit",
+          "voluptate",
+          "velit",
+          "velit",
+          "ipsum"
+        ]
+      }
+    ]
+  },
+  {
+    "_id": "62799a4946542da8cc4e2745",
+    "index": "1",
+    "isActive": false,
+    "age": "40",
+    "name": "Palmer Stevenson",
+    "gender": "male",
+    "phone": "+1 (858) 576-2958",
+    "upgrades": {
+      "vision": {
+        "system": "http://infrared.org",
+        "augmentCode": "strawberry"
+      },
+      "bonemarrow": {
+        "system": "http://illuminated.party",
+        "augmentCode": "chameleon"
+      }
+    },
+    "friends": [
+      {
+        "id": 0,
+        "name": "Marta Garrison",
+        "parents": [
+          {
+            "name": "Sonja Silva",
+            "age": "58",
+            "tags": [
+              "mollit",
+              "nostrud",
+              "laboris",
+              "sint",
+              "quis",
+              "incididunt",
+              "nostrud"
+            ]
+          },
+          {
+            "name": "Stephanie Cash",
+            "age": "58",
+            "tags": [
+              "nostrud",
+              "aliquip",
+              "qui",
+              "sit",
+              "culpa",
+              "nostrud",
+              "irure"
+            ]
+          }
+        ],
+        "favoriteFruit": "A",
+        "tags": [
+          "nisi",
+          "non",
+          "non",
+          "eu",
+          "quis",
+          "quis",
+          "consectetur"
+        ]
+      },
+      {
+        "id": 1,
+        "name": "Gilda Battle",
+        "parents": [
+          {
+            "name": "Foreman Conley",
+            "age": "59",
+            "tags": [
+              "excepteur",
+              "ipsum",
+              "voluptate",
+              "ad",
+              "ullamco",
+              "do",
+              "sit"
+            ]
+          },
+          {
+            "name": "Monroe Cannon",
+            "age": "49",
+            "tags": [
+              "occaecat",
+              "reprehenderit",
+              "incididunt",
+              "ex",
+              "aliqua",
+              "in",
+              "aliquip"
+            ]
+          }
+        ],
+        "favoriteFruit": "A",
+        "tags": [
+          "excepteur",
+          "enim",
+          "ad",
+          "in",
+          "pariatur",
+          "dolor",
+          "esse"
+        ]
+      },
+      {
+        "id": 2,
+        "name": "Cline Harrison",
+        "parents": [
+          {
+            "name": "Wendy Salinas",
+            "age": "46",
+            "tags": [
+              "veniam",
+              "enim",
+              "tempor",
+              "adipisicing",
+              "aute",
+              "qui",
+              "nostrud"
+            ]
+          },
+          {
+            "name": "Angeline Graves",
+            "age": "44",
+            "tags": [
+              "officia",
+              "consequat",
+              "qui",
+              "nisi",
+              "duis",
+              "aute",
+              "magna"
+            ]
+          }
+        ],
+        "favoriteFruit": "A",
+        "tags": [
+          "in",
+          "veniam",
+          "dolore",
+          "qui",
+          "duis",
+          "exercitation",
+          "sunt"
+        ]
+      }
+    ]
+  },
+  {
+    "_id": "62799a49e3293e0abb474004",
+    "index": "2",
+    "isActive": true,
+    "age": "22",
+    "name": "Velasquez William",
+    "gender": "male",
+    "phone": "+1 (935) 525-2774",
+    "upgrades": {
+      "vision": {
+        "system": "http://infrared.org",
+        "augmentCode": "strawberry"
+      },
+      "bonemarrow": {
+        "system": "http://illuminated.party",
+        "augmentCode": "goat"
+      }
+    },
+    "friends": [
+      {
+        "id": "0",
+        "name": "Franklin Vaughan",
+        "parents": [
+          {
+            "name": "Mccall Sawyer",
+            "age": "47",
+            "tags": [
+              "do",
+              "mollit",
+              "incididunt",
+              "cupidatat",
+              "pariatur",
+              "aliquip",
+              "sit"
+            ]
+          },
+          {
+            "name": "Patrica Wall",
+            "age": "51",
+            "tags": [
+              "est",
+              "dolor",
+              "nisi",
+              "sint",
+              "id",
+              "ut",
+              "elit"
+            ]
+          }
+        ],
+        "favoriteFruit": "O-",
+        "tags": [
+          "reprehenderit",
+          "aute",
+          "irure",
+          "mollit",
+          "non",
+          "consequat",
+          "deserunt"
+        ]
+      },
+      {
+        "id": "1",
+        "name": "Simpson Manning",
+        "parents": [
+          {
+            "name": "Tami Stewart",
+            "age": "40",
+            "tags": [
+              "laboris",
+              "cupidatat",
+              "duis",
+              "elit",
+              "ad",
+              "eu",
+              "sint"
+            ]
+          },
+          {
+            "name": "Rochelle Norton",
+            "age": "55",
+            "tags": [
+              "sunt",
+              "culpa",
+              "cupidatat",
+              "ea",
+              "occaecat",
+              "velit",
+              "quis"
+            ]
+          }
+        ],
+        "favoriteFruit": "A",
+        "tags": [
+          "amet",
+          "officia",
+          "reprehenderit",
+          "velit",
+          "nostrud",
+          "minim",
+          "magna"
+        ]
+      },
+      {
+        "id": 2,
+        "name": "Tamara Underwood",
+        "parents": [
+          {
+            "name": "Becker Burgess",
+            "age": "59",
+            "tags": [
+              "ex",
+              "irure",
+              "culpa",
+              "sint",
+              "occaecat",
+              "quis",
+              "id"
+            ]
+          },
+          {
+            "name": "Michelle Shelton",
+            "age": "45",
+            "tags": [
+              "quis",
+              "sunt",
+              "sunt",
+              "dolor",
+              "proident",
+              "elit",
+              "minim"
+            ]
+          }
+        ],
+        "favoriteFruit": "O-",
+        "tags": [
+          "nisi",
+          "est",
+          "aliquip",
+          "nulla",
+          "est",
+          "consequat",
+          "ullamco"
+        ]
+      }
+    ]
+  },
+  {
+    "_id": "62799a493f9c829f60942a77",
+    "index": "3",
+    "isActive": false,
+    "age": "28",
+    "name": "Sabrina Holcomb",
+    "gender": "female",
+    "phone": "+1 (935) 530-2761",
+    "upgrades": {
+      "vision": {
+        "system": "http://infrared.org",
+        "augmentCode": "strawberry"
+      },
+      "bonemarrow": {
+        "system": "http://illuminated.party",
+        "augmentCode": "giraffe"
+      }
+    },
+    "friends": [
+      {
+        "id": "0",
+        "name": "Holland Ochoa",
+        "parents": [
+          {
+            "name": "Shannon Robles",
+            "age": "46",
+            "tags": [
+              "aliqua",
+              "ullamco",
+              "sunt",
+              "occaecat",
+              "quis",
+              "sint",
+              "laboris"
+            ]
+          },
+          {
+            "name": "Odessa Herring",
+            "age": "50",
+            "tags": [
+              "pariatur",
+              "elit",
+              "ex",
+              "laboris",
+              "velit",
+              "ex",
+              "ad"
+            ]
+          }
+        ],
+        "favoriteFruit": "A",
+        "tags": [
+          "commodo",
+          "labore",
+          "fugiat",
+          "magna",
+          "ad",
+          "sint",
+          "qui"
+        ]
+      },
+      {
+        "id": 1,
+        "name": "Velez Knapp",
+        "parents": [
+          {
+            "name": "Selma Mckay",
+            "age": "41",
+            "tags": [
+              "duis",
+              "consectetur",
+              "labore",
+              "quis",
+              "do",
+              "id",
+              "cillum"
+            ]
+          },
+          {
+            "name": "Shannon Romero",
+            "age": "53",
+            "tags": [
+              "voluptate",
+              "fugiat",
+              "magna",
+              "ullamco",
+              "adipisicing",
+              "ut",
+              "enim"
+            ]
+          }
+        ],
+        "favoriteFruit": "A",
+        "tags": [
+          "velit",
+          "est",
+          "enim",
+          "labore",
+          "exercitation",
+          "quis",
+          "do"
+        ]
+      },
+      {
+        "id": 2,
+        "name": "Atkins Tyson",
+        "parents": [
+          {
+            "name": "Louisa Mooney",
+            "age": "47",
+            "tags": [
+              "sunt",
+              "duis",
+              "esse",
+              "aute",
+              "est",
+              "ad",
+              "amet"
+            ]
+          },
+          {
+            "name": "Ellison Wiley",
+            "age": "54",
+            "tags": [
+              "elit",
+              "aliquip",
+              "dolor",
+              "dolore",
+              "pariatur",
+              "ad",
+              "non"
+            ]
+          }
+        ],
+        "favoriteFruit": "O-",
+        "tags": [
+          "ut",
+          "enim",
+          "adipisicing",
+          "eiusmod",
+          "aute",
+          "culpa",
+          "dolore"
+        ]
+      }
+    ]
+  },
+  {
+    "_id": "62799a493866d4148e43769a",
+    "index": "4",
+    "isActive": true,
+    "age": "26",
+    "name": "Swanson Davis",
+    "gender": "male",
+    "phone": "+1 (949) 565-3675",
+    "upgrades": {
+      "vision": {
+        "system": "http://infrared.org",
+        "augmentCode": "banana"
+      },
+      "bonemarrow": {
+        "system": "http://illuminated.party",
+        "augmentCode": "chameleon"
+      }
+    },
+    "friends": [
+      {
+        "id": 0,
+        "name": "Benson Mckenzie",
+        "parents": [
+          {
+            "name": "Lynnette Donovan",
+            "age": "51",
+            "tags": [
+              "esse",
+              "sit",
+              "eiusmod",
+              "aute",
+              "magna",
+              "consectetur",
+              "dolore"
+            ]
+          },
+          {
+            "name": "Elisa Velasquez",
+            "age": "59",
+            "tags": [
+              "non",
+              "tempor",
+              "do",
+              "do",
+              "minim",
+              "ullamco",
+              "ullamco"
+            ]
+          }
+        ],
+        "favoriteFruit": "B",
+        "tags": [
+          "eu",
+          "officia",
+          "culpa",
+          "cillum",
+          "anim",
+          "duis",
+          "laboris"
+        ]
+      },
+      {
+        "id": 1,
+        "name": "Grant Kennedy",
+        "parents": [
+          {
+            "name": "Shepherd Hendricks",
+            "age": "42",
+            "tags": [
+              "tempor",
+              "pariatur",
+              "deserunt",
+              "tempor",
+              "magna",
+              "nulla",
+              "ex"
+            ]
+          },
+          {
+            "name": "Viola Winters",
+            "age": "46",
+            "tags": [
+              "deserunt",
+              "consectetur",
+              "et",
+              "eu",
+              "nostrud",
+              "consequat",
+              "aute"
+            ]
+          }
+        ],
+        "favoriteFruit": "O-",
+        "tags": [
+          "proident",
+          "deserunt",
+          "aliquip",
+          "ullamco",
+          "magna",
+          "anim",
+          "ut"
+        ]
+      },
+      {
+        "id": 2,
+        "name": "Aline Wilkins",
+        "parents": [
+          {
+            "name": "Morton Mueller",
+            "age": "47",
+            "tags": [
+              "quis",
+              "consectetur",
+              "exercitation",
+              "minim",
+              "aute",
+              "proident",
+              "minim"
+            ]
+          },
+          {
+            "name": "Mildred Weeks",
+            "age": "44",
+            "tags": [
+              "aute",
+              "officia",
+              "reprehenderit",
+              "laborum",
+              "reprehenderit",
+              "consequat",
+              "proident"
+            ]
+          }
+        ],
+        "favoriteFruit": "B",
+        "tags": [
+          "incididunt",
+          "nostrud",
+          "aliqua",
+          "cillum",
+          "eu",
+          "culpa",
+          "in"
+        ]
+      }
+    ]
+  },
+  {
+    "_id": "62799a49af6526466cf52d08",
+    "index": "5",
+    "isActive": false,
+    "age": "40",
+    "name": "Patty Pittman",
+    "gender": "female",
+    "phone": "+1 (833) 475-2518",
+    "upgrades": {
+      "vision": {
+        "system": "http://infrared.org",
+        "augmentCode": "strawberry"
+      },
+      "bonemarrow": {
+        "system": "http://illuminated.party",
+        "augmentCode": "chameleon"
+      }
+    },
+    "friends": [
+      {
+        "id": 0,
+        "name": "Margo Gordon",
+        "parents": [
+          {
+            "name": "Jarvis Langley",
+            "age": "58",
+            "tags": [
+              "magna",
+              "officia",
+              "nostrud",
+              "culpa",
+              "laborum",
+              "qui",
+              "proident"
+            ]
+          },
+          {
+            "name": "Foley Case",
+            "age": "60",
+            "tags": [
+              "eiusmod",
+              "cupidatat",
+              "aute",
+              "esse",
+              "cupidatat",
+              "pariatur",
+              "ad"
+            ]
+          }
+        ],
+        "favoriteFruit": "A",
+        "tags": [
+          "nisi",
+          "dolor",
+          "ipsum",
+          "duis",
+          "reprehenderit",
+          "minim",
+          "Lorem"
+        ]
+      },
+      {
+        "id": 1,
+        "name": "Holt Wynn",
+        "parents": [
+          {
+            "name": "Fry Perry",
+            "age": "51",
+            "tags": [
+              "sint",
+              "dolore",
+              "excepteur",
+              "enim",
+              "proident",
+              "ad",
+              "est"
+            ]
+          },
+          {
+            "name": "Brandie Short",
+            "age": "53",
+            "tags": [
+              "ea",
+              "veniam",
+              "et",
+              "irure",
+              "eu",
+              "tempor",
+              "duis"
+            ]
+          }
+        ],
+        "favoriteFruit": "O-",
+        "tags": [
+          "ea",
+          "pariatur",
+          "sunt",
+          "incididunt",
+          "ut",
+          "in",
+          "occaecat"
+        ]
+      },
+      {
+        "id": 2,
+        "name": "Roseann Hanson",
+        "parents": [
+          {
+            "name": "Lucinda Mitchell",
+            "age": "53",
+            "tags": [
+              "id",
+              "culpa",
+              "exercitation",
+              "deserunt",
+              "laborum",
+              "anim",
+              "dolor"
+            ]
+          },
+          {
+            "name": "Walter Kim",
+            "age": "40",
+            "tags": [
+              "in",
+              "irure",
+              "officia",
+              "nostrud",
+              "irure",
+              "adipisicing",
+              "reprehenderit"
+            ]
+          }
+        ],
+        "favoriteFruit": "O-",
+        "tags": [
+          "excepteur",
+          "anim",
+          "do",
+          "ipsum",
+          "cupidatat",
+          "ipsum",
+          "adipisicing"
+        ]
+      }
+    ]
+  },
+  {
+    "_id": "62799a498a22028150ec4547",
+    "index": "6",
+    "isActive": true,
+    "age": "22",
+    "name": "Latisha Prince",
+    "gender": "female",
+    "phone": "+1 (808) 501-2964",
+    "upgrades": {
+      "vision": {
+        "system": "http://infrared.org/other",
+        "augmentCode": "apple"
+      },
+      "bonemarrow": {
+        "system": "http://illuminated.party",
+        "augmentCode": "goat"
+      }
+    },
+    "friends": [
+      {
+        "id": "0",
+        "name": "Mcmillan Cameron",
+        "parents": [
+          {
+            "name": "Howe Pruitt",
+            "age": "58",
+            "tags": [
+              "consectetur",
+              "dolore",
+              "nostrud",
+              "quis",
+              "nostrud",
+              "ad",
+              "laborum"
+            ]
+          },
+          {
+            "name": "Bernadine Gillespie",
+            "age": "40",
+            "tags": [
+              "ea",
+              "tempor",
+              "magna",
+              "ullamco",
+              "dolore",
+              "cupidatat",
+              "deserunt"
+            ]
+          }
+        ],
+        "favoriteFruit": "O-",
+        "tags": [
+          "ex",
+          "sunt",
+          "laboris",
+          "qui",
+          "dolore",
+          "eu",
+          "consequat"
+        ]
+      },
+      {
+        "id": "1",
+        "name": "Melba Merrill",
+        "parents": [
+          {
+            "name": "Trevino Wilson",
+            "age": "58",
+            "tags": [
+              "ad",
+              "ullamco",
+              "tempor",
+              "consectetur",
+              "labore",
+              "eu",
+              "labore"
+            ]
+          },
+          {
+            "name": "Allison Lloyd",
+            "age": "48",
+            "tags": [
+              "anim",
+              "excepteur",
+              "anim",
+              "ipsum",
+              "laborum",
+              "cillum",
+              "elit"
+            ]
+          }
+        ],
+        "favoriteFruit": "B",
+        "tags": [
+          "consequat",
+          "deserunt",
+          "commodo",
+          "sit",
+          "consequat",
+          "aute",
+          "incididunt"
+        ]
+      },
+      {
+        "id": 2,
+        "name": "Pennington Sweet",
+        "parents": [
+          {
+            "name": "Huber Bauer",
+            "age": "52",
+            "tags": [
+              "aliquip",
+              "esse",
+              "do",
+              "voluptate",
+              "sint",
+              "proident",
+              "anim"
+            ]
+          },
+          {
+            "name": "Arlene Lawson",
+            "age": "49",
+            "tags": [
+              "et",
+              "enim",
+              "elit",
+              "aute",
+              "fugiat",
+              "tempor",
+              "esse"
+            ]
+          }
+        ],
+        "favoriteFruit": "O-",
+        "tags": [
+          "dolor",
+          "excepteur",
+          "dolor",
+          "aliqua",
+          "sit",
+          "esse",
+          "irure"
+        ]
+      }
+    ]
+  }
+]

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.UnitTests/Utilities/ComplexObjectFilterUtilityTests.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.UnitTests/Utilities/ComplexObjectFilterUtilityTests.cs
@@ -1,0 +1,67 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.Collections.Generic;
+using System.IO;
+using Microsoft.Health.Fhir.Liquid.Converter.Extensions;
+using Microsoft.Health.Fhir.Liquid.Converter.Utilities;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+using TestCase = Microsoft.Health.Fhir.Liquid.Converter.UnitTests.Models.ComplexObjectFilterUtilityTestCase;
+
+namespace Microsoft.Health.Fhir.Liquid.Converter.UnitTests.Utilities
+{
+    public class ComplexObjectFilterUtilityTests
+    {
+        [Fact]
+        public void GivenObjectAndPath_SelectCorrectObjectsFromArray()
+        {
+            var testContent = File.ReadAllText("./TestData/ComplexObject.json");
+            var testData = (object[])JToken.Parse(testContent).ToObject();
+            var tests = new TestCase[]
+            {
+                new TestCase(testData, "age", "27", new object[] { testData[0] }),
+                new TestCase(testData, "upgrades.vision.system", "http://infrared.org/other", new object[] { testData[6] }),
+                new TestCase(testData, "friends[0].name", "Holland Ochoa", new object[] { testData[3] }),
+                new TestCase(testData, "friends[0].name", "Holland Ochoa", new object[] { testData[3] }),
+                new TestCase(testData, "friends[].parents[].tags[2]", "ex", new object[] { testData[3] }),
+                new TestCase(testData, "friends[].parents[].tags[2]", "hex", new object[] { }),
+                new TestCase(testData, "upgrades.bonemarrow.system", "http://illuminated.party", testData),
+            };
+
+            foreach (TestCase testCase in tests)
+            {
+                var expected = testCase.Expected;
+                var actualData = ComplexObjectFilterUtility.Select(testCase.Input, testCase.Path, testCase.Value);
+                Assert.Equal(expected, actualData);
+            }
+        }
+
+        [Fact]
+        public void GivenPath_WhenSplitToParts_CorrectPartsShouldBeReturned()
+        {
+            var testData = new Dictionary<string, string[]>
+            {
+                // Path                      Expected parts
+                { "test.path[].to[5].value", new string[] { "test", "path", "[]", "to", "[5]", "value" } },
+                { "test",                    new string[] { "test" } },
+                { "test.path",               new string[] { "test", "path" } },
+                { "[].[5].test.path[5]",     new string[] { "[]", "[5]", "test", "path", "[5]" } },
+                { "[5]",                     new string[] { "[5]" } },
+                { "[]",                      new string[] { "[]" } },
+                { "[559]",                   new string[] { "[559]" } },
+            };
+
+            foreach (KeyValuePair<string, string[]> data in testData)
+            {
+                var path = data.Key;
+                var expected = new Queue<string>(data.Value);
+                var actual = ComplexObjectFilterUtility.SplitObjectPath(path);
+                Assert.Equal(expected, actual);
+            }
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Liquid.Converter/Filters/CollectionFilters.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter/Filters/CollectionFilters.cs
@@ -3,6 +3,8 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
@@ -11,6 +13,7 @@ using DotLiquid;
 using Microsoft.Health.Fhir.Liquid.Converter.DotLiquids;
 using Microsoft.Health.Fhir.Liquid.Converter.Exceptions;
 using Microsoft.Health.Fhir.Liquid.Converter.Models;
+using Microsoft.Health.Fhir.Liquid.Converter.Utilities;
 
 namespace Microsoft.Health.Fhir.Liquid.Converter
 {
@@ -64,7 +67,33 @@ namespace Microsoft.Health.Fhir.Liquid.Converter
             return null;
         }
 
-        //public static object FilterByKeyWithValue(object[] input, string key, string value)
+        public static object Slice(object input, int s, int n = 1)
+        {
+            if (input != null)
+            {
+                if (input is string inputString)
+                {
+                    if (inputString.Length > s + n)
+                    {
+                        return inputString.Skip(s).Take(n);
+                    }
+                }
+                else if (input is object[] collection)
+                {
+                    if (collection.Count() > s + n)
+                    {
+                        return collection.Skip(s).Take(n);
+                    }
+                }
+            }
+
+            return null;
+        }
+
+        public static object[] Select(object[] input, string path, string value = null)
+        {
+            return ComplexObjectFilterUtility.Select(input, path, value);
+        }
 
         public static object FilterByKeyWithValue(object[] input, string key, string needle)
         {
@@ -85,7 +114,6 @@ namespace Microsoft.Health.Fhir.Liquid.Converter
                 for (int k = 0; k < keys.Count() - 1; k++)
                 {
                     var cKey = keys[k];
-                    //Console.WriteLine(cKey);
                     if (res.ContainsKey(cKey))
                     {
                         res = (Dictionary<string, object>)res[cKey];

--- a/src/Microsoft.Health.Fhir.Liquid.Converter/Utilities/ComplexObjectFilterUtility.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter/Utilities/ComplexObjectFilterUtility.cs
@@ -1,0 +1,174 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Microsoft.Health.Fhir.Liquid.Converter.Utilities
+{
+    public static class ComplexObjectFilterUtility
+    {
+        private static readonly char[] Delimeters = new[] { '.', '[', ']' };
+
+        public static object[] Select(object[] input, string path, string value = null)
+        {
+            // Split path on . and [], [5]
+            Queue<string> pathKeys = SplitObjectPath(path);
+
+            List<object> ret = new List<object>();
+
+            foreach (object obj in input)
+            {
+                // Clone the queue to scope the path at this level for each loop
+                var localPath = new Queue<string>(pathKeys);
+                if (ObjHasValueAtPath(obj, localPath, value))
+                {
+                    // This object has our value at the path so add it to our return
+                    ret.Add(obj);
+                }
+            }
+
+            return ret.ToArray<object>();
+        }
+
+        public static bool ObjHasValueAtPath(object input, Queue<string> path, string value)
+        {
+            // If we're at the end of the path then check the value
+            if (path.Count == 0)
+            {
+                // Return true if value is null and an equality check otherwise
+                return value == null || input.ToString().Equals(value);
+            }
+
+            // Get our key name
+            var key = path.Dequeue();
+
+            // Check if our key is an object property or an array reference
+            if (key.Contains('['))
+            {
+                // Our required path dictates we should have an array and if not
+                // then this is not a match
+                if (input is object[] inputArray)
+                {
+                    // If key is [] then we want to loop over every object in the array
+                    // and check for our future paths
+                    if (key == "[]")
+                    {
+                        if (path.Count == 0)
+                        {
+                            // TODO: Can value matter when path ends in indiscriminite array?
+                            return true;
+                        }
+
+                        foreach (object obj in inputArray)
+                        {
+                            // Clone the queue to scope the path at this level for each loop
+                            var localPath = new Queue<string>(path);
+                            if (ObjHasValueAtPath(obj, localPath, value))
+                            {
+                                return true;
+                            }
+                        }
+
+                        return false;
+                    }
+
+                    // If our array key references a specific index
+                    else
+                    {
+                        // Trim and parse out our numeric index
+                        var indexStr = key.TrimStart('[').TrimEnd(']');
+                        var index = int.Parse(indexStr);
+
+                        if (index >= 0 && inputArray.Count() > index)
+                        {
+                            // Recurse
+                            return ObjHasValueAtPath(inputArray[index], path, value);
+                        }
+                        else
+                        {
+                            // It's not possible for this array to have the element specified
+                            // so this is not a match
+                            return false;
+                        }
+                    }
+                }
+                else
+                {
+                    return false;
+                }
+            }
+
+            // Our key is referencing an object property
+            else
+            {
+                if (input is Dictionary<string, object> inputObject)
+                {
+                    if (inputObject.ContainsKey(key))
+                    {
+                        // Recurse
+                        return ObjHasValueAtPath(inputObject[key], path, value);
+                    }
+                }
+
+                return false;
+            }
+        }
+
+        // This function splits a string into an array of parts like
+        // `test.path[].to[5].value` -> ['test', 'path', '[]', 'to', '[5]', 'value']
+        public static Queue<string> SplitObjectPath(string path)
+        {
+            var parts = new Queue<string>();
+            var part = new StringBuilder();
+            var bracket = false;
+
+            for (int i = 0; i < path.Length; i++)
+            {
+                if (Delimeters.Contains(path[i]) == false)
+                {
+                    // Any char that isn't a delimeter gets saved
+                    part.Append(path[i]);
+                }
+
+                if (path[i] == '[')
+                {
+                    if (part.Length > 0)
+                    {
+                        // Perform a split
+                        parts.Enqueue(part.ToString());
+                        part.Clear();
+                    }
+
+                    // Brackets do not get stripped
+                    part.Append(path[i]);
+
+                    // Begin a bracket split
+                    bracket = true;
+                }
+
+                if (path[i] == ']')
+                {
+                    // Brackets do not get stripped
+                    part.Append(path[i]);
+
+                    // Break out of the bracket split
+                    bracket = false;
+                }
+
+                // Split on . if we're not in a bracket or if we're at the end of string
+                if ((path[i] == '.' && !bracket) || i == path.Length - 1)
+                {
+                    parts.Enqueue(part.ToString());
+                    part.Clear();
+                }
+            }
+
+            return parts;
+        }
+    }
+}


### PR DESCRIPTION
This pull request creates a utility that can be used to filter an array of object by deeply nested properties, using only a string and return the topmost object.

The query string can be formatted:

`objectKey.array[].objectKey.array[2]`

Arrays can be specifically referenced or not. When inspecific, a match will be made when any object inside that array matches the rest of the value and or path.